### PR TITLE
Allow single member import of withExtraArgument

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,17 @@ function fetchUser(id) {
 }
 ```
 
+You can also import `withExtraArgument` as a single member;
+
+```js
+import { withExtraArgument } from 'redux-thunk';
+
+const store = createStore(
+  reducer,
+  applyMiddleware(withExtraArgument({ api, whatever }))
+)
+```
+
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,4 +11,5 @@ function createThunkMiddleware(extraArgument) {
 const thunk = createThunkMiddleware();
 thunk.withExtraArgument = createThunkMiddleware;
 
+export const withExtraArgument = thunk.withExtraArgument;
 export default thunk;

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import thunkMiddleware from '../src/index';
+import { withExtraArgument } from '../src/index';
 
 describe('thunk middleware', () => {
   const doDispatch = () => {};
@@ -81,6 +82,19 @@ describe('thunk middleware', () => {
     it('must pass the third argument', done => {
       const extraArg = { lol: true };
       thunkMiddleware.withExtraArgument(extraArg)({
+        dispatch: doDispatch,
+        getState: doGetState,
+      })()((dispatch, getState, arg) => {
+        chai.assert.strictEqual(dispatch, doDispatch);
+        chai.assert.strictEqual(getState, doGetState);
+        chai.assert.strictEqual(arg, extraArg);
+        done();
+      });
+    });
+
+    it('can be imported as a single member of the module', done => {
+      const extraArg = { lol: true };
+      withExtraArgument(extraArg)({
         dispatch: doDispatch,
         getState: doGetState,
       })()((dispatch, getState, arg) => {


### PR DESCRIPTION
I love this new `withExtraArgument` feature! Makes it easier to do dependency injection, especially for testing purposes. However, it seems kinda weird that we need to call `thunk.withExtraArgument`. Doesn't seem consistent with the other redux related libraries. Figured I'd fix it :)
