### PR TITLE
declare own Dispatch and Store interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
-import {Middleware, Dispatch} from "redux";
+import { Action, Middleware, Dispatch as ReduxDispatch, Store as ReduxStore } from "redux";
 
-
-export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
-                                    extraArgument: E) => R;
-
-declare module "redux" {
-  export interface Dispatch<S> {
+export interface Dispatch<S> extends ReduxDispatch<S> {
     <R, E>(asyncAction: ThunkAction<R, S, E>): R;
-  }
 }
 
+export interface Store<S> extends ReduxStore<S> {
+    dispatch: Dispatch<S>;
+}
+
+export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
+                                extraArgument: E) => R;
 
 declare const thunk: Middleware & {
-  withExtraArgument(extraArgument: any): Middleware;
+    withExtraArgument(extraArgument: any): Middleware;
 };
 
 export default thunk;

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,6 +1,5 @@
-import {Store, Middleware} from 'redux';
-import thunk, {ThunkAction} from '../index.d.ts';
-
+import { Action, Dispatch as ReduxDispatch, Middleware } from 'redux';
+import thunk, { Dispatch, ThunkAction, Store } from '../index.d.ts';
 
 declare const store: Store<{foo: string}>;
 
@@ -30,4 +29,8 @@ const thunkAction: ThunkAction<void, {foo: string}, {bar: number}> =
 
 const thunkActionDispatchOnly: ThunkAction<void, {}, {}> = dispatch => {
   dispatch({type: 'FOO'});
+};
+
+export const otherMiddleware: Middleware = (store: Store<any>) => (next: ReduxDispatch<any>) => (action: Action) => {
+  next(action);
 };


### PR DESCRIPTION
The current implementation of the typings makes it impossible
to create a middleware that only handles standard actions. This means
a middleware must handle thunked actions even though it never actually
handles them during runtime. (see issue and examples in #82)

By declaring the `Dispatch` and `Store` interfaces again instead of
overloading the original implementation of `redux` a consumer of
`redux-thunk` can choose the right implementation for his use case
(e.g. `ActionCreator` vs. `Middleware`).

fixes #82
