### PR TITLE
add module exports plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "add-module-exports",
     ["transform-es2015-template-literals", { "loose": true }],
     "transform-es2015-literals",
     "transform-es2015-function-name",

--- a/.babelrc
+++ b/.babelrc
@@ -24,6 +24,7 @@
   "env": {
     "commonjs": {
       "plugins": [
+        "add-module-exports",
         ["transform-es2015-modules-commonjs", { "loose": true }],
       ]
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-core": "^6.6.5",
     "babel-eslint": "^5.0.0-beta4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-check-es2015-constants": "^6.6.5",
     "babel-plugin-transform-es2015-arrow-functions": "^6.5.2",
     "babel-plugin-transform-es2015-block-scoped-functions": "^6.6.5",


### PR DESCRIPTION
instead of having to require the module with `.default` in commonjs, why not just provide the export it wants?
