### PR TITLE
AsyncAction should accept ThunkAction or Action

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
 
 declare module "redux" {
   export interface Dispatch<S> {
-    <R, E>(asyncAction: ThunkAction<R, S, E>): R;
+    <R, E>(asyncAction: ThunkAction<R, S, E> | S): R;
   }
 }
 


### PR DESCRIPTION
Overwriting default redux Dispatch type should be able to handle both the type for ThunkAction and the Type for the Redux Dispatch 

Fix related to this issue:
https://github.com/gaearon/redux-thunk/issues/82

Example of a fix with a failing test:

https://github.com/codebandits/typescript-react-starter/blob/master/src/main/actions/__test__/actions.test.ts#L8-L12