### PR TITLE
Allow Dispatch of Redux actions as well

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {Middleware, Dispatch} from "redux";
+import {Middleware, Dispatch, Action} from "redux";
 
 
 export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
@@ -6,10 +6,9 @@ export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
 
 declare module "redux" {
   export interface Dispatch<S> {
-    <R, E>(asyncAction: ThunkAction<R, S, E>): R;
+    <R, E, A extends Action>(asyncAction: ThunkAction<R, S, E> | A): R;
   }
 }
-
 
 declare const thunk: Middleware & {
   withExtraArgument(extraArgument: any): Middleware;


### PR DESCRIPTION
Using the redux thunk middleware conflicts with other middlewares we have because it redefines incorrectly the redux Dispatch interface. This redefinition allows only for ThunkActions/functions to be dispatched but it should allow to dispatch normal Redux actions as well.