### PR TITLE
Add support for Flux Standard Actions (FSAs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,26 @@ function fetchUser(id) {
 }
 ```
 
+## Flux Standard Actions
+
+Action creators that return [Flux Standard Actions (FSAs)](https://github.com/acdlite/flux-standard-action)
+are supported out of the box:
+
+```js
+function myFsaActionCreator() {
+  return {
+    type: 'SOME_ASYNC_THING',
+    payload: () => {
+      return (dispatch, getState) => {
+        setTimeout(() => {
+          dispatch({type: 'ANOTHER ACTION'});
+        }, 1000)
+      }
+    }
+  }
+}
+```
+
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 function createThunkMiddleware(extraArgument) {
   return ({ dispatch, getState }) => next => action => {
+    // Flux standard actions
+    if (typeof action === 'object' && typeof action.payload === 'function') {
+      return action.payload(dispatch, getState, extraArgument);
+    }
     if (typeof action === 'function') {
       return action(dispatch, getState, extraArgument);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,18 @@ describe('thunk middleware', () => {
         });
       });
 
+      it('must run functions at action.payload (flux standard actions) with dispatch and getState', done => {
+        const actionHandler = nextHandler();
+        actionHandler({
+          type: 'TEST',
+          payload: (dispatch, getState) => {
+            chai.assert.strictEqual(dispatch, doDispatch);
+            chai.assert.strictEqual(getState, doGetState);
+            done();
+          },
+        });
+      });
+
       it('must pass action to next if not a function', done => {
         const actionObj = {};
 


### PR DESCRIPTION
Add support for action creators that return Flux Standard Actions:

```js
function myFsaActionCreator() {
  return {
    // Works because action.payload is inspected prior to checking if action is a function
    type: 'SOME_ASYNC_THING',
    payload: () => {
      return (dispatch, getState) => {
        setTimeout(() => {
          dispatch({type: 'ANOTHER ACTION'});
        }, 1000)
      }
    }
  }
}
```