### PR TITLE
Add module entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.0",
   "description": "Thunk middleware for Redux.",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "typings": "./index.d.ts",
   "files": [


### PR DESCRIPTION
`jsnext:main` is somewhat deprecated and some might argue it should be completely replaced with `module`. Personally I don't care about extra field in `package.json` if it helps somebody, OTOH if we leave it hanging everywhere it will still be here with us for next few years and that is harmful for the ecosystem. Your choice  ¯\\_(ツ)_/¯
