### PR TITLE
Add 'module' entry in package.json for Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "redux-thunk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Thunk middleware for Redux.",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "typings": "./index.d.ts",
   "files": [


### PR DESCRIPTION
#### Description
To enable webpack transpile with default babel 'commonjs'('modules' not specified in .babelrc)

#### reproduce in my project
package.json
```
"webpack": "^3.11.0",
```
.babelrc
```
{
  "presets": [
    ["env", {
      "targets": {
        // See: http://browserl.ist/?q=defaults%2C+last+5+Safari+versions
        "browsers": [
          "defaults",
          "last 5 Safari versions"
        ]
      },
      "debug": true
    }],
    "react",
    "stage-2"
  ],
  "plugins": [
    "transform-class-properties",
    "transform-export-extensions",
    "transform-object-assign"
  ]
}
```
`yarn add` to use, I always get:
`TypeError: Cannot assign to read only property '__esModule' of #<Object>`
Apparently my webpack transpiled a wrong commonjs version from `lib/index.js`(entry 'main' in package.json) instead of an ES version.

#### QA
Refer to https://github.com/webpack/webpack/issues/2902. Why my webpack seems not work with `jsnext:main` entry but default `module`?
