### PR TITLE
Added 'module' entry for module file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Thunk middleware for Redux.",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
+  "module": "es/index.js",
   "typings": "./index.d.ts",
   "files": [
     "lib",


### PR DESCRIPTION
Unsure as to whether to replace `jsnext:main` with `module` entirely, or to add as an extra entry for the time being. As far as I know `module` is now the *standard*, but I'm sure many libs out there rely solely on `jsnext:main` &ndash; that's why I opted for the latter 👍 