### PR TITLE
Allow action to be typed with any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import { Middleware, Action, AnyAction } from "redux";
 
 export interface ThunkDispatch<S, E, A extends Action> {
-  <T extends A>(action: T): T;
   <R>(thunkAction: ThunkAction<R, S, E, A>): R;
+  <T extends A>(action: T): T;
 }
 
 export type ThunkAction<R, S, E, A extends Action> = (

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -78,3 +78,12 @@ const callDispatchAsync_anyAction = (dispatch: ThunkDispatch<State, undefined, a
   const asyncThunk = (): ThunkResult<Promise<void>> => () => ({} as Promise<void>);
   dispatch(asyncThunk()).then(() => console.log('done'))
 }
+const callDispatchAsync_specificActions = (dispatch: ThunkDispatch<State, undefined, Actions>) => {
+  const asyncThunk = (): ThunkResult<Promise<void>> => () => ({} as Promise<void>);
+  dispatch(asyncThunk()).then(() => console.log('done'))
+}
+const callDispatchAny = (dispatch: ThunkDispatch<State, undefined, Actions>) => {
+  const asyncThunk = (): any => () => ({} as Promise<void>);
+  dispatch(asyncThunk()) // result is any
+    .then(() => console.log('done')) 
+}

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import thunk, { ThunkAction, ThunkMiddleware } from '../index';
+import thunk, { ThunkAction, ThunkMiddleware, ThunkDispatch } from '../index';
 
 type State = {
   foo: string;
@@ -73,3 +73,8 @@ storeThunkArg.dispatch((dispatch, getState, extraArg) => {
   store.dispatch({ type: 'BAZ'});
   console.log(extraArg);
 });
+
+const callDispatchAsync_anyAction = (dispatch: ThunkDispatch<State, undefined, any>) => {
+  const asyncThunk = (): ThunkResult<Promise<void>> => () => ({} as Promise<void>);
+  dispatch(asyncThunk()).then(() => console.log('done'))
+}


### PR DESCRIPTION
By swapping the order of the calls, the Action param can be any. From https://github.com/reduxjs/redux-thunk/issues/213#issuecomment-428380685
