### PR TITLE
Add overload for bindActionCreators

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,10 @@
-import { Middleware, Action, AnyAction } from "redux";
+import {
+  Action,
+  ActionCreatorsMapObject,
+  AnyAction,
+  Dispatch,
+  Middleware,
+} from 'redux';
 
 export interface ThunkDispatch<S, E, A extends Action> {
   <R>(thunkAction: ThunkAction<R, S, E, A>): R;
@@ -18,3 +24,17 @@ declare const thunk: ThunkMiddleware & {
 }
 
 export default thunk;
+
+/**
+ * Redux behaviour changed by middleware, so overloads here
+ */
+declare module 'redux' {
+  /**
+   * Overload for bindActionCreators redux function, returns expects responses
+   * from thunk actions
+   */
+  function bindActionCreators<M extends ActionCreatorsMapObject<any>>(
+    actionCreators: M,
+    dispatch: Dispatch,
+  ): { [N in keyof M]: ReturnType<M[N]> extends ThunkAction<any, any, any, any> ? (...args: Parameters<M[N]>) => ReturnType<ReturnType<M[N]>> : M[N] }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ export type ThunkAction<R, S, E, A extends Action> = (
  *
  * @template T ThunkAction to be wrapped
  */
-export type ThunkActionDispatch<T extends ThunkAction<any, any, any, any>> = (...args: Parameters<T>)
+export type ThunkActionDispatch<T extends (...args: any[]) => ThunkAction<any, any, any, any>> = (...args: Parameters<T>)
   => ReturnType<ReturnType<T>>;
 
 export type ThunkMiddleware<S = {}, A extends Action = AnyAction, E = undefined> = Middleware<ThunkDispatch<S, E, A>, S, ThunkDispatch<S, E, A>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,15 @@ export type ThunkAction<R, S, E, A extends Action> = (
   extraArgument: E
 ) => R;
 
+/**
+ * Takes a ThunkAction and returns a function signature which matches how it would appear when processed using
+ * bindActionCreators
+ *
+ * @template T ThunkAction to be wrapped
+ */
+export type ThunkActionDispatch<T extends ThunkAction<any, any, any, any>> = (...args: Parameters<T>)
+  => ReturnType<ReturnType<T>>;
+
 export type ThunkMiddleware<S = {}, A extends Action = AnyAction, E = undefined> = Middleware<ThunkDispatch<S, E, A>, S, ThunkDispatch<S, E, A>>;
 
 declare const thunk: ThunkMiddleware & {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3652,9 +3652,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
     },
     "typings-tester": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "mocha": "^2.2.5",
     "redux": "~4.0.0",
     "rimraf": "^2.5.2",
-    "typescript": "~2.6.2",
+    "typescript": "^3.1.6",
     "typings-tester": "^0.3.1",
     "webpack": "^1.12.14"
   }

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,5 +1,14 @@
-import { createStore, applyMiddleware } from 'redux';
-import thunk, { ThunkAction, ThunkMiddleware, ThunkDispatch } from '../index';
+import {
+  applyMiddleware,
+  bindActionCreators,
+  createStore,
+} from 'redux';
+
+import thunk, {
+  ThunkAction,
+  ThunkDispatch,
+  ThunkMiddleware,
+} from '../index';
 
 type State = {
   foo: string;
@@ -50,6 +59,34 @@ function anotherThunkAction(): ThunkResult<string> {
   }
 }
 
+function promiseThunkAction(): ThunkResult<Promise<boolean>> {
+  return async (dispatch, getState) => {
+    dispatch({ type: 'FOO' });
+    return false;
+  }
+}
+
+const standardAction = () => ({ type: 'FOO' });
+
+// test that bindActionCreators correctly returns actions responses of ThunkActions
+// also ensure standard action creators still work as expected
+const actions = bindActionCreators({
+  anotherThunkAction,
+  promiseThunkAction,
+  standardAction,
+}, store.dispatch);
+
+actions.anotherThunkAction() === 'hello';
+// typings:expect-error
+actions.anotherThunkAction() === false;
+actions.promiseThunkAction().then((res) => console.log(res));
+// typings:expect-error
+actions.promiseThunkAction().prop;
+actions.standardAction().type;
+// typings:expect-error
+actions.standardAction().other;
+
+
 store.dispatch({ type: 'FOO' });
 // typings:expect-error
 store.dispatch({ type: 'BAR' })
@@ -85,5 +122,5 @@ const callDispatchAsync_specificActions = (dispatch: ThunkDispatch<State, undefi
 const callDispatchAny = (dispatch: ThunkDispatch<State, undefined, Actions>) => {
   const asyncThunk = (): any => () => ({} as Promise<void>);
   dispatch(asyncThunk()) // result is any
-    .then(() => console.log('done')) 
+    .then(() => console.log('done'))
 }

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -6,6 +6,7 @@ import {
 
 import thunk, {
   ThunkAction,
+  ThunkActionDispatch,
   ThunkDispatch,
   ThunkMiddleware,
 } from '../index';
@@ -68,13 +69,21 @@ function promiseThunkAction(): ThunkResult<Promise<boolean>> {
 
 const standardAction = () => ({ type: 'FOO' });
 
+interface ActionDispatchs {
+  anotherThunkAction: ThunkActionDispatch<typeof anotherThunkAction>;
+  promiseThunkAction: ThunkActionDispatch<typeof promiseThunkAction>;
+  standardAction: typeof standardAction;
+}
+
 // test that bindActionCreators correctly returns actions responses of ThunkActions
 // also ensure standard action creators still work as expected
-const actions = bindActionCreators({
+const actions: ActionDispatchs = bindActionCreators({
   anotherThunkAction,
   promiseThunkAction,
   standardAction,
 }, store.dispatch);
+
+
 
 actions.anotherThunkAction() === 'hello';
 // typings:expect-error


### PR DESCRIPTION
As per #223, redux's `bindActionCreators` only works nicely for standard action creators. This implementation infers the return type of ThunkActions so the application could respond accordingly. E.g. action fires an XHR, the application has no way of knowing when the XHR has resolved, other than through watching the state. This way, you can now have promise resolution in your application outside of the redux store.

I've updated the TypeScript version to 3.1, this gives us access to the `Parameters` generic, the `ReturnType` generic, and conditional types.

Feedback welcome

Note, the should fix the concerns from the now closed #213 