### PR TITLE
Make getState and extraArgument optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,8 @@ export interface ThunkDispatch<S, E, A extends Action> {
 
 export type ThunkAction<R, S, E, A extends Action> = (
   dispatch: ThunkDispatch<S, E, A>,
-  getState: () => S,
-  extraArgument: E
+  getState?: () => S,
+  extraArgument?: E
 ) => R;
 
 export type ThunkMiddleware<S = {}, A extends Action = AnyAction, E = undefined> = Middleware<ThunkDispatch<S, E, A>, S, ThunkDispatch<S, E, A>>;


### PR DESCRIPTION
Should make it more obvious that `getState` and `extraArgument` are not needed, also fixes some inferrence issues when using `RemoveDispatch` from this SO thread: https://stackoverflow.com/questions/49424666/typescript-redux-thunk-types