### PR TITLE
Allowing extra argument to get state from store

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,20 @@ function fetchUser(id) {
 }
 ```
 
+### Using state in your custom argument
+If you need some dynamic configuration in your custom argument (like an api token in a multi-tenant application), you can pass a function that receives the getState function, returning the custom argument. Example:
+
+```js
+const someArg = getState => ({
+  myDinamyValue: getState().myValue
+  myStaticValue: 123
+});
+
+const store = createStore(
+  reducer,
+  applyMiddleware(thunk.withExtraArgument(someArg))
+)
+```
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 function createThunkMiddleware(extraArgument) {
   return ({ dispatch, getState }) => next => action => {
     if (typeof action === 'function') {
-      return action(dispatch, getState, extraArgument);
+      return action(
+        dispatch,
+        getState,
+        typeof extraArgument === 'function'
+          ? extraArgument(getState)
+          : extraArgument
+      );
     }
 
     return next(action);

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,24 @@ describe('thunk middleware', () => {
         done();
       });
     });
+
+    it('must call with `getState` when is function', done => {
+      const extraArg = getState => {
+        chai.assert.strictEqual(getState, doGetState);
+        return { argGetState: getState };
+      };
+
+      thunkMiddleware.withExtraArgument(extraArg)({
+        dispatch: doDispatch,
+        getState: doGetState,
+      })()((dispatch, getState, arg) => {
+        chai.assert.strictEqual(dispatch, doDispatch);
+        chai.assert.strictEqual(getState, doGetState);
+        chai.assert.strictEqual(arg.argGetState, doGetState);
+        chai.assert.deepEqual(arg, extraArg(doGetState));
+        done();
+      });
+    });
   });
 
   describe('TypeScript definitions', function test() {


### PR DESCRIPTION
Some features require dynamic configs like user locale and language or api tokens for multi-tenant applications. A great place to keep something like an axios instance with headreds and authentication configured is in the extra argument, allowing you to use all this configuration without need to think in it and without repeating code.

When you keep some token for a multi-tenant application in your store, you need to get this token every time you need a request, so this change will improve this kind of pattern.

Before:
```javascript
const someArg = { myStaticValue: 123 };
thunk.withExtraArgument(someArg);
```

Now:
```javascript
const someArg = getState => ({
  myDinamyValue: getState().myValue
  myStaticValue: 123
});
thunk.withExtraArgument(someArg);
```

In my researches I found other developers with a similar problem that could be solved with this change. I think this could help lots of people (like #160 , #136 and some others around the internet).

Is important to mention that **this is not a breaking change**. So everyone should keep their lives the same way with this PR =)