### PR TITLE
Add Dispatch overload to Redux module.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,6 +94,16 @@ export default thunk;
  * Redux behaviour changed by middleware, so overloads here
  */
 declare module "redux" {
+  /*
+   * Overload to add thunk support to Redux's dispatch() function.
+   * Useful for react-redux or any other library which could use this type.
+   */
+  export interface Dispatch<A extends Action = AnyAction> {
+    <TReturnType, TState, TExtraThunkArg, TBasicAction extends Action>(
+      thunk: ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>
+    ): TReturnType;
+  }
+
   /**
    * Overload for bindActionCreators redux function, returns expects responses
    * from thunk actions


### PR DESCRIPTION
Similarly to the `bindActionCreators` overload, this extends Redux to dispatch thunks and provide the correct return values. This prevents us from needing to build thunk support into `react-redux`.

I could use some advice on testing this one. The following is an error, as it appears that this Dispatch import receives the interface before the redux-thunk declarations are merged:

```
import { Dispatch } from "redux";
type ExtendedDispatch = Dispatch<ThunkResult<boolean>>;
```

Understanding what's happening here might help me remove inlined thunk logic from `connect()` typings in react-redux.

I've tested this in a real-world application with react-redux hooks typings (https://github.com/MrWolfZ/DefinitelyTyped/pull/3) in two forms:
```
const thunkAction = () => {
  return (dispatch: Dispatch, getState: () => State) => {
    return dispatch({ type: "SET_STATE" });
  };
};
const dispatch = useDispatch();
// typeof result === { type: "SET_STATE" }
const result = dispatch(thunkAction()) 

// typeof result === { type: "SET_STATE" }
const result = dispatch((thunkDispatch, getState) => { // correctly infers dispatch + getState
  return thunkDispatch();
});
```