### PR TITLE
Use spread arguments instead of object destructing when passing extra argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,17 +322,17 @@ function fetchUser(id) {
 }
 ```
 
-To pass multiple things, just wrap them in a single object and use destructuring:
+You can pass multiple extra arguments:
 
 ```js
 const store = createStore(
   reducer,
-  applyMiddleware(thunk.withExtraArgument({ api, whatever }))
+  applyMiddleware(thunk.withExtraArgument(api, whatever))
 )
 
 // later
 function fetchUser(id) {
-  return (dispatch, getState, { api, whatever }) => {
+  return (dispatch, getState, api, whatever) => {
     // you can use api and something else here
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-function createThunkMiddleware(extraArgument) {
+function createThunkMiddleware(...extraArguments) {
   return ({ dispatch, getState }) => next => action => {
     if (typeof action === 'function') {
-      return action(dispatch, getState, extraArgument);
+      return action(dispatch, getState, ...extraArguments);
     }
 
     return next(action);


### PR DESCRIPTION
This is not too important change, it's just more handy to use multiple arguments using rest arguments instead of passing object and destructing it. Also it will not break anything on the peoples code. If they use destructing already then they can use it after this change.

The reason I guess it useful change is: for example if you have 500 actions where you already use extra argument and you'd like to add another one. To do it with current structure you need to use object and as result make change to all of 500 actions. With this propose you'll be able to add extra argument to as many actions as you need only.

To add second extra argument to code below:
```js
const action432 = () => (dispatch, state, extra) => ...
const action433 = () => (dispatch, state, extra) => ...
```

With current structure you need to:
```js
// both lines changed 😓
const action432 = () => (dispatch, state, { extra }) => ...
const action433 = () => (dispatch, state, { extra, another }) => ...
```

With this propose you'll be able to:
```js
// note first line did not changed 🎉
const action432 = () => (dispatch, state, extra) => ...
const action433 = () => (dispatch, state, extra, another) => ...
```

If I'm wrong about breaking something after this change please tell me.