### PR TITLE
Add peer dependency on redux 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack",
     "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack"
   },
+  "peerDependencies": {
+    "redux": "^4.0.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-core": "^6.6.5",


### PR DESCRIPTION
As noted in https://github.com/reduxjs/redux-thunk/issues/205#issuecomment-399450331, react-redux 2.3.0 must be used with redux 4.0 for the typescript typings to be correct.

This adds the missing peer dependency to package.json to ensure that users are warned if they attempt to use incompatible combinations of redux and redux-thunk.