### PR TITLE
#248 Add union overload to ThunkDispatch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,11 @@ export interface ThunkDispatch<
   ): TReturnType;
   <A extends TBasicAction>(action: A): A;
   // This overload is the union of the two above (see TS issue #14107).
-  <R, T extends A>(action: T | ThunkAction<R, S, E, A>): T | R;
+  <TReturnType, TAction extends TBasicAction>(
+    action:
+      | TAction
+      | ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>
+  ): TAction | TReturnType;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,8 @@ export interface ThunkDispatch<
     thunkAction: ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>
   ): TReturnType;
   <A extends TBasicAction>(action: A): A;
+  // This overload is the union of the two above (see TS issue #14107).
+  <R, T extends A>(action: T | ThunkAction<R, S, E, A>): T | R;
 }
 
 /**


### PR DESCRIPTION
See discussion in #248 and https://github.com/microsoft/TypeScript/issues/14107. Without this explicit overload, TypeScript is unable to figure out that the function can be called with an argument of type `T|ThunkAction<...>`.