### PR TITLE
Add Dispatch overload to redux module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,6 @@ import {
   Action,
   ActionCreatorsMapObject,
   AnyAction,
-  Dispatch,
   Middleware
 } from "redux";
 
@@ -100,6 +99,18 @@ export default thunk;
  * Redux behaviour changed by middleware, so overloads here
  */
 declare module "redux" {
+  /*
+   * Overload to add thunk support to Redux's dispatch() function.
+   * Useful for react-redux or any other library which could use this type.
+   */
+  export interface Dispatch<
+    A extends Action<any> = AnyAction,
+  > {
+    <TReturnType, TState, TExtraThunkArg>(
+      thunkAction: ThunkAction<TReturnType, TState, TExtraThunkArg, A>
+    ): TReturnType;
+  }
+
   /**
    * Overload for bindActionCreators redux function, returns expects responses
    * from thunk actions

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -109,7 +109,7 @@ const storeThunkArg = createStore(
   applyMiddleware(thunk.withExtraArgument('bar') as ThunkMiddleware<State, Actions, string>)
 );
 
-storeThunkArg.dispatch((dispatch, getState, extraArg) => {
+const thunkAction: ThunkAction<void, State, string, Actions> = (dispatch, getState, extraArg) => {
   const bar: string = extraArg;
   store.dispatch({ type: 'FOO' });
   // typings:expect-error
@@ -118,7 +118,10 @@ storeThunkArg.dispatch((dispatch, getState, extraArg) => {
   // typings:expect-error
   store.dispatch({ type: 'BAZ'});
   console.log(extraArg);
-});
+}
+
+// thunkAction must be explicitly typed
+storeThunkArg.dispatch(thunkAction);
 
 const callDispatchAsync_anyAction = (dispatch: ThunkDispatch<State, undefined, any>) => {
   const asyncThunk = (): ThunkResult<Promise<void>> => () => ({} as Promise<void>);


### PR DESCRIPTION
Follow up from
 #247

Adds `Dispatch` interface override to work with `redux-thunk`.