### PR TITLE
fix: extraThunkArgument types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,9 +89,13 @@ export type ThunkMiddleware<
 >;
 
 declare const thunk: ThunkMiddleware & {
-  withExtraArgument<TExtraThunkArg>(
+  withExtraArgument<
+    TExtraThunkArg,
+    TState = {},
+    TBasicAction extends Action<any> = AnyAction
+  >(
     extraArgument: TExtraThunkArg
-  ): ThunkMiddleware<{}, AnyAction, TExtraThunkArg>;
+  ): ThunkMiddleware<TState, TBasicAction, TExtraThunkArg>;
 };
 
 export default thunk;


### PR DESCRIPTION
Support specifying `TState` and `TBasicAction` types when calling `thunk.withExtraArgument`.

_This is backwards compatible with the previous types._