### PR TITLE
Correct destructuring example

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,13 @@ function fetchUser(id) {
 }
 ```
 
-To pass multiple things, just wrap them in a single object and use
-destructuring:
+To pass multiple things, just wrap them in a single object. 
+Using ES2015 shorthand property names can make this more concise.
 
 ```js
+const api = "http://www.example.com/sandwiches/";
+const whatever = 42;
+
 const store = createStore(
   reducer,
   applyMiddleware(thunk.withExtraArgument({ api, whatever })),


### PR DESCRIPTION
`{ api, whatever }` from line 342 is not actually destructuring — though both were introduced in ES2015, the name for this syntax is "Shorthand property names":

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015

I also added some example variables to make the code sample more accessible to beginners.