### PR TITLE
Use "sh" instead of "js" in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Thunk [middleware](https://redux.js.org/advanced/middleware) for Redux.
 [![npm version](https://img.shields.io/npm/v/redux-thunk.svg?style=flat-square)](https://www.npmjs.com/package/redux-thunk)
 [![npm downloads](https://img.shields.io/npm/dm/redux-thunk.svg?style=flat-square)](https://www.npmjs.com/package/redux-thunk)
 
-```js
+```sh
 npm install redux-thunk
 
 yarn add redux-thunk


### PR DESCRIPTION
I noticed that the installation shell commands used `js` instead of `sh`, which potentially affects syntax highlighting.

This minor change updates that.