### PR TITLE
Remove redundant `|`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,9 +28,7 @@ export interface ThunkDispatch<
   <A extends TBasicAction>(action: A): A;
   // This overload is the union of the two above (see TS issue #14107).
   <TReturnType, TAction extends TBasicAction>(
-    action:
-      | TAction
-      | ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>,
+    action: TAction | ThunkAction<TReturnType, TState, TExtraThunkArg, TBasicAction>,
   ): TAction | TReturnType;
 }
 


### PR DESCRIPTION
I don't recall why I put it there, probably just a mistake.