### PR TITLE
Improve action return value resolution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ['3.9', '4.0', '4.1', '4.2', '4.3', '4.4', 'next']
+        ts: ['3.9', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', 'next']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you use Redux Thunk 2.x in a CommonJS environment,
 ```
 
 Additionally, since 2.x, we also support a
-[UMD build](https://unpkg.com/redux-thunk/dist/redux-thunk.min.js):
+[UMD build](https://unpkg.com/redux-thunk/dist/redux-thunk.min.js) for use as a global script tag:
 
 ```js
 const ReduxThunk = window.ReduxThunk
@@ -76,7 +76,6 @@ import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import rootReducer from './reducers/index'
 
-// Note: this API requires redux@>=3.1.0
 const store = createStore(rootReducer, applyMiddleware(thunk))
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "redux-thunk",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.15.7",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,22 +11,26 @@ import { Action, AnyAction, Middleware, Dispatch } from 'redux'
  * thunks (if specified when setting up the Thunk middleware)
  * @template BasicAction The (non-thunk) actions that can be dispatched.
  */
-export interface ThunkDispatch<State, ExtraThunkArg, BasicAction extends Action>
-  extends Dispatch<BasicAction> {
-  // When the thunk middleware is added, `store.dispatch` now has three overloads:
+export interface ThunkDispatch<
+  State,
+  ExtraThunkArg,
+  BasicAction extends Action
+> {
+  // When the thunk middleware is added, `store.dispatch` now has three overloads (NOTE: the order here matters for correct behavior and is very fragile - do not reorder these!):
 
-  // 1) The base overload, which accepts a standard action object, and returns that action object
-
-  // 2) The specific thunk function overload
+  // 1) The specific thunk function overload
   /** Accepts a thunk function, runs it, and returns whatever the thunk itself returns */
   <ReturnType>(
     thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>
   ): ReturnType
 
-  // 3)
-  /** A union of the other two overloads. This overload exists to work around a problem
-   *  with TS inference ( see https://github.com/microsoft/TypeScript/issues/14107 )
-   */
+  // 2) The base overload.
+  /** Accepts a standard action object, and returns that action object */
+  <Action extends BasicAction>(action: Action): Action
+
+  // 3) A union of the other two overloads. This overload exists to work around a problem
+  //   with TS inference ( see https://github.com/microsoft/TypeScript/issues/14107 )
+  /** A union of the other two overloads for TS inference purposes */
   <ReturnType, Action extends BasicAction>(
     action: Action | ThunkAction<ReturnType, State, ExtraThunkArg, BasicAction>
   ): Action | ReturnType


### PR DESCRIPTION
This PR:

- Re-adds an explicit `ThunkDispatch` overload for a plain `action` object, due to https://github.com/reduxjs/redux-toolkit/issues/1705