### PR TITLE
Remove unused type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Action, AnyAction, Middleware, Dispatch } from 'redux'
+import { Action, AnyAction, Middleware } from 'redux'
 
 /**
  * The dispatch method as modified by React-Thunk; overloaded so that you can


### PR DESCRIPTION
Fix importing these types while using  `noUnusedLocals` config, since skipLibCheck can't prevent this.