### PR TITLE
Add ability to spy on dispatch called by thunks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,18 +20,19 @@ function createThunkMiddleware<
   // Standard Redux middleware definition pattern:
   // See: https://redux.js.org/tutorials/fundamentals/part-4-store#writing-custom-middleware
   const middleware: ThunkMiddleware<State, BasicAction, ExtraThunkArg> =
-    ({ dispatch, getState }) =>
-    next =>
-    action => {
-      // The thunk middleware looks for any functions that were passed to `store.dispatch`.
-      // If this "action" is really a function, call it and return the result.
-      if (typeof action === 'function') {
-        // Inject the store's `dispatch` and `getState` methods, as well as any "extra arg"
-        return action(dispatch, getState, extraArgument)
-      }
+    store => {
+      if (!store) throw new Error('ThunkMiddleware requires a store')
+      return next => action => {
+        // The thunk middleware looks for any functions that were passed to `store.dispatch`.
+        // If this "action" is really a function, call it and return the result.
+        if (typeof action === 'function') {
+          // Inject the store's `dispatch` and `getState` methods, as well as any "extra arg"
+          return action(store.dispatch, store.getState, extraArgument)
+        }
 
-      // Otherwise, pass the action down the middleware chain as usual
-      return next(action)
+        // Otherwise, pass the action down the middleware chain as usual
+        return next(action)
+      }
     }
   return middleware
 }


### PR DESCRIPTION
Fixes #335

 2 unit tests were added that don't pass with the current implementation and do pass with fixed implementation

### Generated code also keeps the references for `dispatch` and `getState` updated
<img width="699" alt="image" src="https://user-images.githubusercontent.com/1834409/200368757-e8a7a63e-b46c-4a76-9ac2-2c401be53546.png">
