### PR TITLE
Enforce type imports where applicable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
     "import/no-unresolved": "off",
     "import/named": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
+    "@typescript-eslint/consistent-type-imports": ["error"],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/member-delimiter-style": "off",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Action, AnyAction, Middleware } from 'redux'
+import type { Action, AnyAction, Middleware } from 'redux'
 
 /**
  * The dispatch method as modified by React-Thunk; overloaded so that you can

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -4,6 +4,7 @@
   },
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/consistent-type-imports": ["error"],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-use-before-define": "off",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "strict": true,
+    "importsNotUsedAsValues": "error",
     "target": "ES2015"
   },
   "include": ["**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
+    "importsNotUsedAsValues": "error",
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",

--- a/typescript_test/.eslintrc
+++ b/typescript_test/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/consistent-type-imports": ["error"],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-unused-vars": "off",

--- a/typescript_test/tsconfig.json
+++ b/typescript_test/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "strict": true,
+    "importsNotUsedAsValues": "error",
     "target": "ES2015"
   },
   "include": ["typescript.ts"]

--- a/typescript_test/typescript.ts
+++ b/typescript_test/typescript.ts
@@ -1,13 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  applyMiddleware,
-  bindActionCreators,
-  createStore,
-  Action,
-  AnyAction
-} from 'redux'
+import { applyMiddleware, bindActionCreators, createStore } from 'redux'
+import type { Action, AnyAction } from 'redux'
 
-import thunk, {
+import thunk from '../src/index'
+import type {
   ThunkAction,
   ThunkActionDispatch,
   ThunkDispatch,

--- a/typescript_test/typescript_extended/extended-redux.ts
+++ b/typescript_test/typescript_extended/extended-redux.ts
@@ -9,7 +9,8 @@ import {
   Dispatch
 } from 'redux'
 
-import thunk, {
+import thunk from '../../src/index'
+import type {
   ThunkAction,
   ThunkActionDispatch,
   ThunkDispatch,

--- a/typescript_test/typescript_extended/tsconfig.json
+++ b/typescript_test/typescript_extended/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "strict": true,
+    "importsNotUsedAsValues": "error",
     "target": "ES2015"
   },
   "include": ["extended-redux.ts"]


### PR DESCRIPTION
While not a problem when `redux-thunk` is consumed normally, there are cases (that e.g. my company project just hit) where library types are fetched more directly into the source and their TS code may cause issues when not adhering to the strict rules.

While it would be perfectly understandable to ignore this use case, I think the `importsNotUsedAsValues` flag serves as a nice `strict` extension, making separation between values & types clearer.

See https://github.com/webpack/webpack/issues/7378 as an example for the type of issues that using this flag solves.

I also added ESLint rules enforcing type imports for types; it may seem redundant but the tsconfig flag also prevents regular imports where ALL tokens are only used as types; mixing is allowed. The ESLint rule requires splitting such imports into type & non-type parts.

My particular use case would be solved even without the ESLint rule; if, for some reason, you prefer a bit more lax setup done directly by TS only, I can drop this part. I just added it as I thought it might be useful.