### PR TITLE
Wrap patterns passed to ESLint in single quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepublishOnly": "npm run clean && npm run lint && npm run test && npm run build",
     "format": "prettier --write {src,test,typescript_test}/**/*.{js,ts}",
     "format:check": "prettier --check {src,test,typescript_test}/**/*.{js,ts}",
-    "lint": "eslint {src,test,typescript_test}/**/*.{js,ts}",
+    "lint": "eslint '{src,test,typescript_test}/**/*.{js,ts}'",
     "test": "jest",
     "test:cov": "jest --coverage",
     "test:typescript": "npm run test:typescript:main && npm run test:typescript:extended",


### PR DESCRIPTION
When not wrapped, invoking `npm run lint` on ZSH - the default shell on macOS - makes the pattern evaluated by ZSH. That, in turn, fails, as ZSH detects no files match the pattern `src/**/*.js`. Wrapping the pattern in single quotes makes ESLint evaluate it which works.

I noticed it when trying to publish the latest `master` at my temporary forked scoped package as I need my fix from #338.

I verified this works by changing a type import back into a regular one in `src/types.ts` and running `npm run lint` - it failed as expected.