### PR TITLE
Migrate thunk package to ESM

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,7 +1,7 @@
 const { NODE_ENV, BABEL_ENV } = process.env
 const cjs = NODE_ENV === 'test' || BABEL_ENV === 'commonjs'
 
-module.exports = {
+export default {
   presets: [
     [
       '@babel/preset-env',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: 'npm'
 
       - name: Install deps
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ['3.9', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', 'next']
+        ts: ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9']
 
     steps:
       - name: Checkout code

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */
 
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   coverageDirectory: './coverage/',
@@ -8,7 +8,7 @@ module.exports = {
   testRegex: 'test/test.ts',
   globals: {
     'ts-jest': {
-      tsconfig: './test/tsconfig.json',
-    },
-  },
-};
+      tsconfig: './test/tsconfig.json'
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redux-thunk",
-  "version": "2.4.2",
+  "version": "3.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redux-thunk",
-      "version": "2.4.2",
+      "version": "3.0.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.15.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "redux-thunk",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "redux-thunk",
-      "version": "3.0.0-alpha.0",
+      "version": "3.0.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.15.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-thunk",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "license": "MIT",
   "description": "Thunk middleware for Redux.",
   "repository": "github:reduxjs/redux-thunk",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,18 @@
     "flux"
   ],
   "author": "Dan Abramov <dan.abramov@me.com>",
+  "type": "module",
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./es/index.d.ts",
+      "import": "./es/index.js",
+      "default": "./lib/index.js"
+    }
+  },
   "sideEffects": false,
   "files": [
     "lib",
@@ -30,7 +39,7 @@
     "prepublishOnly": "npm run clean && npm run lint && npm run test && npm run build",
     "format": "prettier --write {src,test,typescript_test}/**/*.{js,ts}",
     "format:check": "prettier --check {src,test,typescript_test}/**/*.{js,ts}",
-    "lint": "eslint '{src,test,typescript_test}/**/*.{js,ts}'",
+    "lint": "eslint {src,test,typescript_test}/**/*.{js,ts}",
     "test": "jest",
     "test:cov": "jest --coverage",
     "test:typescript": "npm run test:typescript:main && npm run test:typescript:extended",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-thunk",
-  "version": "2.4.2",
+  "version": "3.0.0-alpha.0",
   "license": "MIT",
   "description": "Thunk middleware for Redux.",
   "repository": "github:reduxjs/redux-thunk",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "scripts": {
     "clean": "rimraf lib dist es",
     "prepublishOnly": "npm run clean && npm run lint && npm run test && npm run build",
-    "format": "prettier --write {src,test,typescript_test}/**/*.{js,ts}",
-    "format:check": "prettier --check {src,test,typescript_test}/**/*.{js,ts}",
-    "lint": "eslint {src,test,typescript_test}/**/*.{js,ts}",
+    "format": "prettier --write \"{src,test,typescript_test}/**/*.{js,ts}\"",
+    "format:check": "prettier --check \"{src,test,typescript_test}/**/*.{js,ts}\"",
+    "lint": "eslint \"{src,test,typescript_test}/**/*.{js,ts}\"",
     "test": "jest",
     "test:cov": "jest --coverage",
     "test:typescript": "npm run test:typescript:main && npm run test:typescript:extended",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ function createThunkMiddleware<
   return middleware
 }
 
-const thunk = createThunkMiddleware() as ThunkMiddleware & {
+export const thunk = createThunkMiddleware() as ThunkMiddleware & {
   withExtraArgument<
     ExtraThunkArg,
     State = any,
@@ -46,8 +46,6 @@ const thunk = createThunkMiddleware() as ThunkMiddleware & {
   ): ThunkMiddleware<State, BasicAction, ExtraThunkArg>
 }
 
-// Attach the factory function so users can create a customized version
+// Export the factory function so users can create a customized version
 // with whatever "extra arg" they want to inject into their thunks
-thunk.withExtraArgument = createThunkMiddleware
-
-export default thunk
+export const withExtraArgument = createThunkMiddleware

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,4 @@
-import thunkMiddleware from '../src/index'
+import { thunk as thunkMiddleware, withExtraArgument } from '../src/index'
 
 describe('thunk middleware', () => {
   const doDispatch = () => {}
@@ -92,7 +92,7 @@ describe('thunk middleware', () => {
     it('must pass the third argument', done => {
       const extraArg = { lol: true }
       // @ts-ignore
-      thunkMiddleware.withExtraArgument(extraArg)({
+      withExtraArgument(extraArg)({
         dispatch: doDispatch,
         getState: doGetState
       })()((dispatch: any, getState: any, arg: any) => {

--- a/typescript_test/typescript.ts
+++ b/typescript_test/typescript.ts
@@ -2,7 +2,7 @@
 import { applyMiddleware, bindActionCreators, createStore } from 'redux'
 import type { Action, AnyAction } from 'redux'
 
-import thunk from '../src/index'
+import { thunk } from '../src/index'
 import type {
   ThunkAction,
   ThunkActionDispatch,

--- a/typescript_test/typescript_extended/extended-redux.ts
+++ b/typescript_test/typescript_extended/extended-redux.ts
@@ -9,7 +9,7 @@ import {
   Dispatch
 } from 'redux'
 
-import thunk from '../../src/index'
+import { thunk } from '../../src/index'
 import type {
   ThunkAction,
   ThunkActionDispatch,


### PR DESCRIPTION
This PR:

- Migrates the `redux-thunk` package to be full ESM with CJS compat

Also see https://github.com/reduxjs/redux-toolkit/pull/3095