### PR TITLE
[package.json] add ^5.0.0-beta.0" to peerDependencies

### DIFF
--- a/extend-redux.d.ts
+++ b/extend-redux.d.ts
@@ -1,4 +1,4 @@
-import { ThunkAction } from './src/index'
+import type { ThunkAction } from './src/index'
 
 /**
  * Globally alter the Redux `bindActionCreators` and `Dispatch` types to assume

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "redux": "^4"
+    "redux": "^4 || ^5.0.0-beta.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.1.0",

--- a/typescript_test/typescript.ts
+++ b/typescript_test/typescript.ts
@@ -144,9 +144,7 @@ actions.standardAction().other
 
 const untypedStore = createStore(fakeReducer, applyMiddleware(thunk))
 
-// @ts-expect-error
 untypedStore.dispatch(anotherThunkAction())
-// @ts-expect-error
 untypedStore.dispatch(promiseThunkAction()).then(() => Promise.resolve())
 
 // #248: Need a union overload to handle generic dispatched types

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,7 +2547,7 @@ __metadata:
     typescript: ^4.4
     vitest: ^0.29.8
   peerDependencies:
-    redux: ^4
+    redux: ^4 || ^5.0.0-beta.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I saw this error while `yarn install` in [this project](https://github.com/laststance/nsx).

```
error "@reduxjs/toolkit#redux-thunk#redux@^4" doesn't satisfy found match of "redux@5.0.0-beta.0"
```

So I added `|| ^5.0.0-beta.0"` to peerDependencies as same as [react-redux](https://github.com/reduxjs/react-redux/blob/master/package.json#L48)