### PR TITLE
Fix webpack 4 support by setting `target: es2017` for `redux.legacy-esm.js`

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, Options } from 'tsup'
-import fs from 'fs'
+import type { Options } from 'tsup'
+import { defineConfig } from 'tsup'
 
 export default defineConfig(options => {
   const commonOptions: Partial<Options> = {
@@ -15,14 +15,16 @@ export default defineConfig(options => {
       format: ['esm'],
       outExtension: () => ({ js: '.mjs' }),
       dts: true,
-      clean: true,
-      onSuccess() {
-        // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
-        fs.copyFileSync(
-          'dist/redux-thunk.mjs',
-          'dist/redux-thunk.legacy-esm.js'
-        )
-      }
+      clean: true
+    },
+    // Support Webpack 4 by pointing `"module"` to a file with a `.js` extension
+    {
+      ...commonOptions,
+      format: ['esm'],
+      target: 'es2017',
+      dts: false,
+      outExtension: () => ({ js: '.js' }),
+      entry: { 'redux-thunk.legacy-esm': 'src/index.ts' }
     },
     {
       ...commonOptions,


### PR DESCRIPTION
## Overview

Even though this change does not make a difference in output, it would still be good to correct this now just so it doesn't become an issue later on.

## This PR:

  - [X] Fixes webpack 4 support by setting `target: es2017` for `redux.legacy-esm.js` which is related to https://github.com/reduxjs/redux-toolkit/issues/4282 and https://github.com/reduxjs/redux/pull/4687.